### PR TITLE
CentOS 7 fix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,5 @@
 AllCops:
   DisplayCopNames: true
-  Include:
-    - Berksfile
-    - Gemfile
-    - Rakefile
-    - Thorfile
-    - Guardfile
   Exclude:
     - vendor/**/*
     - test/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [1.0.0] - 2018-05-22
+### Updated
+- isuftin@usgs.gov - BREAKING CHANGE: Updated the `default['wade']['web']['ssl']['cert']['location']`
+  and `default['wade']['web']['ssl']['key']['location']` attributes to be a valid URI
 ### Added
+- isuftin@usgs.gov - SSL certificates are now copied from their original location
+to /var/www/ for apache to pick up when starting httpd. This allows CentOS 7 to
+work as expected
 - isuftin@usgs.gov - Added the ability to add a hostname to the server configuration.
   Otherwise, uses the server's actual hostname
 

--- a/Thorfile
+++ b/Thorfile
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'bundler'
 require 'bundler/setup'
 require 'berkshelf/thor'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,11 +3,9 @@ default['wade']['web']['postgres_user'] = 'postgres'
 default['wade']['web']['postgres_addr'] = 'localhost'
 default['wade']['web']['postgres_db'] = 'WADE'
 default['wade']['web']['hostname'] = node['hostname']
-default['wade']['web']['version'] = '0.0.1-1'
+default['wade']['web']['version'] = '0.0.1-7'
 default['wade']['web']['ssl']['active'] = true
-default['wade']['web']['ssl']['cert']['location'] = '/tmp/kitchen/data/example.com.cert'
-default['wade']['web']['ssl']['key']['location'] = '/tmp/kitchen/data/example.com.key'
+default['wade']['web']['ssl']['cert']['location'] = 'file:///tmp/kitchen/data/example.com.cert'
+default['wade']['web']['ssl']['key']['location'] = 'file:///tmp/kitchen/data/example.com.key'
 default['wade']['yum']['repo']['baseurl'] = 'https://cida.usgs.gov/artifactory/rpm'
-
-
 default['wade']['databag']['databag_name'] = 'wade-_default'

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'CPL-1.0'
 description 'Creates a WaDE web server'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version '0.0.2'
+version '1.0.0'
 
 issues_url 'https://github.com/USGS-CIDA/chef-cookbook-wuds-wade/issues'
 source_url 'https://github.com/USGS-CIDA/chef-cookbook-wuds-wade'


### PR DESCRIPTION
- isuftin@usgs.gov - BREAKING CHANGE: Updated the `default['wade']['web']['ssl']['cert']['location']`
  and `default['wade']['web']['ssl']['key']['location']` attributes to be a valid URI
- isuftin@usgs.gov - SSL certificates are now copied from their original location
to /var/www/ for apache to pick up when starting httpd. This allows CentOS 7 to
work as expected